### PR TITLE
Update editor warning color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Kaia Theme 🗻
+# Kaia for Visual Studio Code
 
 A Monokai-inspired theme for Visual Studio Code with a focus on accessible contrast ratios.
 
 ![Screenshot](images/screenshot.png)
 
-# Installation
+## Installation
 1.  In Visual Studio Code, search for `Kaia` in the extensions side bar and install it.
 1.  Click **Reload** to reload Visual Studio Code to make the extension available.
 1.  From the gear menu or the Show All Commands (CTRL + SHIFT + P) menu select: Color Theme > **Kaia**.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "kaia-theme-vscode",
     "displayName": "Kaia",
-    "description": "🗻 A Monokai-inspired theme with a focus on accessible contrast ratios.",
-    "version": "1.1.2",
+    "description": "🎨 A Monokai-inspired theme with a focus on accessible contrast ratios.",
+    "version": "1.1.3",
     "publisher": "ryan0x200",
     "icon": "images/logo.png",
     "license": "MIT",
@@ -17,6 +17,7 @@
     },
     "keywords": [
         "Theme",
+        "Color Theme",
         "Kaia",
         "Kaia Theme",
         "Dark Theme",

--- a/themes/kaia-subtle.json
+++ b/themes/kaia-subtle.json
@@ -105,7 +105,7 @@
 		"editorSuggestWidget.highlightForeground": "#fff9c4",
 		"editorSuggestWidget.selectedBackground": "#1a1a1a",
 		"editorWarning.border": "#00000000",
-		"editorWarning.foreground": "#ffe0b2",
+		"editorWarning.foreground": "#b2ebf2",
 		"editorWhitespace.foreground": "#616161",
 		"editorWidget.background": "#303030",
 		"editorWidget.border": "#303030",

--- a/themes/kaia.json
+++ b/themes/kaia.json
@@ -105,7 +105,7 @@
 		"editorSuggestWidget.highlightForeground": "#fff9c4",
 		"editorSuggestWidget.selectedBackground": "#1a1a1a",
 		"editorWarning.border": "#00000000",
-		"editorWarning.foreground": "#ffcc80",
+		"editorWarning.foreground": "#80deea",
 		"editorWhitespace.foreground": "#616161",
 		"editorWidget.background": "#303030",
 		"editorWidget.border": "#303030",


### PR DESCRIPTION
Update editor warning from orange to cyan to improve distinction between warnings and errors (previously orange and red).